### PR TITLE
feat(rcdst): remove authentication requirement for rural change diagnosic screening tool

### DIFF
--- a/src/routes/research/rural-change-diagnostic-screen/+layout.server.ts
+++ b/src/routes/research/rural-change-diagnostic-screen/+layout.server.ts
@@ -10,24 +10,21 @@ import type { LayoutServerLoad } from './$types';
 export const ssr = false;
 export const prerender = false;
 
-export const load = (async ({ parent, url }) => {
-  const { session } = await parent();
-
-  _ensureAuthentication({
-    session,
-    url,
-    scope: 'application__rural_change_diagnostic_screen',
-    appName: 'Rural change diagnostic screening tool',
-  });
+export const load = (async ({ url }) => {
+  // const { session } = await parent();
+  //
+  // _ensureAuthentication({
+  //   session,
+  //   url,
+  //   scope: 'application__rural_change_diagnostic_screen',
+  //   appName: 'Rural change diagnostic screening tool',
+  // });
 
   const result = await generateTokenSafe(
     RURAL_CHANGE_DIAGNOSTIC_SCREEN_ARCGIS_USERNAME,
     RURAL_CHANGE_DIAGNOSTIC_SCREEN_ARCGIS_PASSWORD,
     url.origin
   );
-
-  // wait 5 seconds
-  await new Promise((resolve) => setTimeout(resolve, 5000));
 
   if (!result.success) {
     throw error(500, result.error.message);


### PR DESCRIPTION
This removes the password screen for the rural change diagnostic screening tool added in #9.
It also removes the 5-second wait for each page load within the rural change diagnostic screening tool (it is not clear why it was even in the code).

We decided that we are not showing enough data to be dangerous. Developers have access to paid data and tools that can target properties for redevelopment, and we have chosen not to display parcel- or neighborhood-level data here.